### PR TITLE
Explicitly set reentrant to `False` for torch checkpointing

### DIFF
--- a/openfold/utils/checkpointing.py
+++ b/openfold/utils/checkpointing.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from functools import partial
 import importlib
 from typing import Any, Tuple, List, Callable, Optional
 
@@ -34,7 +35,7 @@ def get_checkpoint_fn():
     if(deepspeed_is_configured):
         checkpoint = deepspeed.checkpointing.checkpoint
     else:
-        checkpoint = torch.utils.checkpoint.checkpoint
+        checkpoint = partial(torch.utils.checkpoint.checkpoint, use_reentrant=False)
 
     return checkpoint
 

--- a/openfold/utils/checkpointing.py
+++ b/openfold/utils/checkpointing.py
@@ -35,7 +35,7 @@ def get_checkpoint_fn():
     if(deepspeed_is_configured):
         checkpoint = deepspeed.checkpointing.checkpoint
     else:
-        checkpoint = partial(torch.utils.checkpoint.checkpoint, use_reentrant=False)
+        checkpoint = partial(torch.utils.checkpoint.checkpoint, use_reentrant=True)
 
     return checkpoint
 

--- a/openfold/utils/checkpointing.py
+++ b/openfold/utils/checkpointing.py
@@ -35,7 +35,7 @@ def get_checkpoint_fn():
     if(deepspeed_is_configured):
         checkpoint = deepspeed.checkpointing.checkpoint
     else:
-        checkpoint = partial(torch.utils.checkpoint.checkpoint, use_reentrant=True)
+        checkpoint = partial(torch.utils.checkpoint.checkpoint, use_reentrant=False)
 
     return checkpoint
 

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ else:
 
 setup(
     name='openfold',
-    version='2.2.1+dyno',
+    version='2.2.2+dyno',
     description='A PyTorch reimplementation of DeepMind\'s AlphaFold 2',
     author='OpenFold Team',
     author_email='jennifer.wei@omsf.io',

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ else:
 
 setup(
     name='openfold',
-    version='2.2.0+dyno',
+    version='2.2.1+dyno',
     description='A PyTorch reimplementation of DeepMind\'s AlphaFold 2',
     author='OpenFold Team',
     author_email='jennifer.wei@omsf.io',

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ else:
 
 setup(
     name='openfold',
-    version='2.0.0',
+    version='2.2.0+dyno',
     description='A PyTorch reimplementation of DeepMind\'s AlphaFold 2',
     author='OpenFold Team',
     author_email='jennifer.wei@omsf.io',


### PR DESCRIPTION
As discussed [here](https://pytorch.org/docs/2.6/checkpoint.html#torch.utils.checkpoint.checkpoint), torch 2.4 and newer require explicitly passing  to the checkpointing function. Prior to torch 2.4 (e.g. 2.2), `use_reentrant` defaulted to True, however we initially found that reentrant checkpointing does not work with DDP and torch.compile [1]. As a result, this change forces `use_reentrant=False` to enable us to use torch.compile with our structure models.

[1]: 
```
[rank0]: RuntimeError: Expected to mark a variable ready only once. This error is caused by one of the following reasons:
 1) Use of a module parameter outside the `forward` function. Please make sure model parameters are not shared across multiple concurrent forward-backward passes or try to use _set_static_graph() as a workaround if this module graph does not change during training loop. 2) Reused parameters in multiple reentrant backward passes. For example, if you use multiple `checkpoint` functions to wrap the same part of your model, it would result in the same set of parameters been used by different reentrant backward passes multiple times, and hence marking a variable ready multiple times. DDP does not support such use cases in default. You can try to use _set_static_graph() as a workaround if your module graph does not change 
over iterations.                                      
```