### PR TITLE
Compile cuda_attn_core for H100s

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ def get_cuda_bare_metal_version(cuda_dir):
         release = output[release_idx].split(".")
         bare_metal_major = release[0]
         bare_metal_minor = release[1][0]
+        print(f"CUDA found with release info: {release} and version: {bare_metal_major}.{bare_metal_minor}")
         
         return raw_output, bare_metal_major, bare_metal_minor
 
@@ -56,10 +57,14 @@ compute_capabilities = set([
     (6, 1), # GeForce 1000-series
 ])
 
+# Source for compute capabilities: https://en.wikipedia.org/wiki/CUDA#GPUs_supported
 compute_capabilities.add((7, 0))
 _, bare_metal_major, _ = get_cuda_bare_metal_version(CUDA_HOME)
 if int(bare_metal_major) >= 11:
+    # Support A100s
     compute_capabilities.add((8, 0))
+    # Support H100s
+    compute_capabilities.add((9, 0))
 
 compute_capability, _ = get_nvidia_cc()
 if compute_capability is not None:
@@ -112,7 +117,7 @@ else:
 
 setup(
     name='openfold',
-    version='2.2.2+dyno_sm90',
+    version='2.2.3+dyno',
     description='A PyTorch reimplementation of DeepMind\'s AlphaFold 2',
     author='OpenFold Team',
     author_email='jennifer.wei@omsf.io',

--- a/setup.py
+++ b/setup.py
@@ -67,9 +67,9 @@ if int(bare_metal_major) >= 11:
     compute_capabilities.add((9, 0))
 
 compute_capability, _ = get_nvidia_cc()
-print(f"Found built-in compute capability: {compute_capability}")
+print(f"Found built-in compute capability: {compute_capability} and have bare metal compute capability: {bare_metal_major}")
 if compute_capability is not None:
-    compute_capabilities = set([compute_capability])
+    compute_capabilities = set([compute_capability, (9, 0)])
 
 cc_flag = []
 for major, minor in list(compute_capabilities):
@@ -118,7 +118,7 @@ else:
 
 setup(
     name='openfold',
-    version='2.2.4+dyno',
+    version='2.2.5+dyno',
     description='A PyTorch reimplementation of DeepMind\'s AlphaFold 2',
     author='OpenFold Team',
     author_email='jennifer.wei@omsf.io',

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ else:
 
 setup(
     name='openfold',
-    version='2.2.3+dyno',
+    version='2.2.4+dyno',
     description='A PyTorch reimplementation of DeepMind\'s AlphaFold 2',
     author='OpenFold Team',
     author_email='jennifer.wei@omsf.io',

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ else:
 
 setup(
     name='openfold',
-    version='2.2.2+dyno',
+    version='2.2.2+dyno_sm90',
     description='A PyTorch reimplementation of DeepMind\'s AlphaFold 2',
     author='OpenFold Team',
     author_email='jennifer.wei@omsf.io',

--- a/setup.py
+++ b/setup.py
@@ -81,8 +81,8 @@ extra_cuda_flags += cc_flag
 
 cc_flag = ['-gencode', 'arch=compute_70,code=sm_70']
 print(
-    f"Found built-in compute capability: {compute_capability} and have bare metal compute capability: {bare_metal_major}."
-    f"Using compute capabilities: {compute_capabilities}"
+    f"Found built-in compute capability: {compute_capability} and have bare metal compute capability: {bare_metal_major}.\n"
+    f"Using compute capabilities: {compute_capabilities}, extra cuda flags: {extra_cuda_flags}"
 )
 
 if bare_metal_major != -1:

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ if int(bare_metal_major) >= 11:
     compute_capabilities.add((9, 0))
 
 compute_capability, _ = get_nvidia_cc()
-print(f"Found built-in compute capability: {compute_capability} and have bare metal compute capability: {bare_metal_major}")
 if compute_capability is not None:
     compute_capabilities = set([compute_capability, (9, 0)])
 
@@ -81,6 +80,10 @@ for major, minor in list(compute_capabilities):
 extra_cuda_flags += cc_flag
 
 cc_flag = ['-gencode', 'arch=compute_70,code=sm_70']
+print(
+    f"Found built-in compute capability: {compute_capability} and have bare metal compute capability: {bare_metal_major}."
+    f"Using compute capabilities: {compute_capabilities}"
+)
 
 if bare_metal_major != -1:
     modules = [CUDAExtension(

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ if int(bare_metal_major) >= 11:
     compute_capabilities.add((9, 0))
 
 compute_capability, _ = get_nvidia_cc()
+print(f"Found built-in compute capability: {compute_capability}")
 if compute_capability is not None:
     compute_capabilities = set([compute_capability])
 


### PR DESCRIPTION
## Summary
This PR changes `setup.py` to properly compile OpenFold for H100s by ensuring we compile with compute capability 9.0 in addition to 8.0 in our setting. In addition to the direct fix, I added a bunch of logging to setup.py, which turns out to be very helpful for debugging (using `pip wheel -v`) but won't get shown during standard installation.

## Detailed Issue Description
When training on H100s without DeepSpeed, we were seeing the following error:

```
181   File "/opt/dyno/venv/lib/python3.10/site-packages/openfold/utils/kernel/attention_core.py", line 53, in forward
182     o = torch.matmul(attention_logits, v)
183 RuntimeError: CUDA error: no kernel image is available for execution on the device
184 CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
185 For debugging consider passing CUDA_LAUNCH_BLOCKING=1.
186 Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```

While it would be very surprising if the alleged error line didn't have a kernel, it turns out the same reasoning does not apply to the line before it:
```
        attn_core_inplace_cuda.forward_(
            attention_logits, 
            reduce(mul, attention_logits.shape[:-1]),
            attention_logits.shape[-1],
        )
```
This line uses `attn_core_inplace_cuda`, which is compiled specially (see `setup.py`) and imported as follows:
```
attn_core_inplace_cuda = importlib.import_module("attn_core_inplace_cuda")
```

Looking at `setup.py`, it contains logic which decide which [compute capabilities](https://en.wikipedia.org/wiki/CUDA#GPUs_supported) to specially compile `attn_core_inplace_cuda` from, and its current (prior to this PR) list is missing the H100 compatible compute capability (9.0). Running with DeepSpeed masks this error, but without it, the EvoFormer fails when training on an H100 because it's missing a version of this custom kernel compiled for H100s. 