### PR TITLE
Add option to zero center positions to `get_custom_template_features`

### DIFF
--- a/openfold/data/templates.py
+++ b/openfold/data/templates.py
@@ -951,7 +951,9 @@ def get_custom_template_features(
         query_sequence: str,
         pdb_id: str,
         chain_id: str,
-        kalign_binary_path: str):
+        kalign_binary_path: str,
+        _zero_center_positions: bool = True,
+    ):
 
     with open(mmcif_path, "r") as mmcif_path:
         cif_string = mmcif_path.read()
@@ -973,7 +975,7 @@ def get_custom_template_features(
         query_sequence=query_sequence,
         template_chain_id=chain_id,
         kalign_binary_path=kalign_binary_path,
-        _zero_center_positions=True
+        _zero_center_positions=_zero_center_positions,
     )
     features["template_sum_probs"] = [1.0]
 

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ else:
 
 setup(
     name='openfold',
-    version='2.2.5+dyno',
+    version='2.2.6+dyno',
     description='A PyTorch reimplementation of DeepMind\'s AlphaFold 2',
     author='OpenFold Team',
     author_email='jennifer.wei@omsf.io',


### PR DESCRIPTION
Add option for whether or not to zero center positions in `get_custom_template_features`. Previously, this was set to True by default in `get_custom_template_features`. However, for the multimer dataset this led to an issue where the template positions were slightly offset from the true atom positions (where we [don't zero center the positions](https://github.com/dynotx/openfold/blob/3011a015acae72ec5e2317a1f07e7b7312ad27c0/openfold/data/mmcif_parsing.py#L438)).

![screenshot_2025-04-18_at_4 40 19___pm_480](https://github.com/user-attachments/assets/5e1b94d0-3907-4909-b875-babae6f72fec)

After running `get_custom_template_features` with `_zero_center_positions = False`, the resulting structures look more aligned:
![Screenshot 2025-04-22 at 3 21 13 PM](https://github.com/user-attachments/assets/5deaa6a0-0868-46f7-8d0a-3a24fe4d34b6)

